### PR TITLE
Discourage use of relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The critical points are:
 * 79 character line limit
 * Variables, functions and methods should be `lower_case_with_underscores`
 * Classes are `TitleCase`
+* Do not use relative imports (eg `from .. import xx`),  always use absolute ones (eg `from mypkg import xx`)
 
 And other preferences:
 


### PR DESCRIPTION
Relative imports are discouraged by PEP8:

> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path ):

It does allow some exceptions 

> when dealing with complex package layouts where using absolute imports would be unnecessarily verbose

But even in these cases I think it's worth having absolute imports as they are much more explicit and avoid confusion when working on multiple libraries.

They also prevent some techniques like dynamically loading of modules in some situations.

I put this item in the "Critical points" section because I loathe them but I'm definitely happy to put them under "Other Preferences" if people don't feel so strongly :) (or to not include if people oppose to it of course)